### PR TITLE
Added options for disabling Romaji and/or Translations

### DIFF
--- a/Safarikai.safariextension/Info.plist
+++ b/Safarikai.safariextension/Info.plist
@@ -5,7 +5,7 @@
 	<key>Author</key>
 	<string>James Chen</string>
 	<key>Builder Version</key>
-	<string>9537.73.11</string>
+	<string>11601.6.17</string>
 	<key>CFBundleDisplayName</key>
 	<string>Safarikai</string>
 	<key>CFBundleIdentifier</key>
@@ -54,6 +54,8 @@
 	</dict>
 	<key>Description</key>
 	<string>Translate Japanese words on web pages.</string>
+	<key>DeveloperIdentifier</key>
+	<string>0000000000</string>
 	<key>ExtensionInfoDictionaryVersion</key>
 	<string>1.0</string>
 	<key>Permissions</key>

--- a/Safarikai.safariextension/Settings.plist
+++ b/Safarikai.safariextension/Settings.plist
@@ -10,7 +10,7 @@
 		<key>Key</key>
 		<string>enabled</string>
 		<key>Title</key>
-		<string>Translate</string>
+		<string>Enabled</string>
 		<key>TrueValue</key>
 		<string>on</string>
 		<key>Type</key>
@@ -23,6 +23,32 @@
 		<string>highlightText</string>
 		<key>Title</key>
 		<string>Highlight</string>
+		<key>TrueValue</key>
+		<string>on</string>
+		<key>Type</key>
+		<string>CheckBox</string>
+	</dict>
+	<dict>
+		<key>DefaultValue</key>
+		<string>off</string>
+		<key>FalseValue</key>
+		<string>off</string>
+		<key>Key</key>
+		<string>showRomaji</string>
+		<key>Title</key>
+		<string>Show Romaji</string>
+		<key>TrueValue</key>
+		<string>on</string>
+		<key>Type</key>
+		<string>CheckBox</string>
+	</dict>
+	<dict>
+		<key>DefaultValue</key>
+		<string>on</string>
+		<key>Key</key>
+		<string>showTranslation</string>
+		<key>Title</key>
+		<string>Show Translation</string>
 		<key>TrueValue</key>
 		<string>on</string>
 		<key>Type</key>

--- a/src/global.coffee
+++ b/src/global.coffee
@@ -4,10 +4,16 @@ window.Safarikai =
     @result    = ""
 
   sendStatus: (page) ->
-    page.dispatchMessage "status", enabled: @enabled(), highlightText: safari.extension.settings.highlightText is 'on'
+    page.dispatchMessage "status", enabled: @enabled(), highlightText: safari.extension.settings.highlightText is 'on', showRomaji: @showRomaji(), showTranslation: @showTranslation()
 
   enabled: ->
     safari.extension.settings.enabled is 'on'
+
+  showRomaji: ->
+    safari.extension.settings.showRomaji is 'on'
+
+  showTranslation: ->
+    safari.extension.settings.showTranslation is 'on'
 
   toggle: ->
     safari.extension.settings.enabled = if @enabled() then 'off' else 'on'

--- a/src/injected.coffee
+++ b/src/injected.coffee
@@ -1,12 +1,14 @@
 class Client
   constructor: (@doc, @window) ->
-    @clientX       = 0
-    @clientY       = 0
-    @popupTagId    = "safarikai-popup"
-    @enabled       = true
-    @mouseDown     = false
-    @highlighted   = false
-    @highlightText = true
+    @clientX         = 0
+    @clientY         = 0
+    @popupTagId      = "safarikai-popup"
+    @enabled         = true
+    @mouseDown       = false
+    @highlighted     = false
+    @highlightText   = true
+    @showRomaji      = true
+    @showTranslation = true
     @rangeOffset   = 0
 
     @doc.onmousemove = (e) =>
@@ -106,10 +108,10 @@ class Client
     <li>
       <div class='kana'>#{ row.kana }</div>
       #{ if kanji.length > 0 then "<div class='kanji'>" + kanji + "</div>" else "" }
-      <div class='translation'>
-        <div class='romaji'>[#{ row.romaji }]</div>
-        #{ row.translation }
-      </div>
+      #{ if @showRomaji or @showTranslation then "<div class='translation'>" else "" }
+        #{ if @showRomaji then "<div class='romaji'>[" + row.romaji + "]</div>" else "" }
+        #{ if @showTranslation then "#{row.translation}" else "" }
+      #{ if @showRomaji or @showTranslation then "</div>" else "" }
     </li>
     """
 
@@ -139,8 +141,10 @@ class Client
       popup.style.top = top + "px"
 
   updateStatus: (status) ->
-    @enabled       = status.enabled
-    @highlightText = status.highlightText
+    @enabled         = status.enabled
+    @highlightText   = status.highlightText
+    @showRomaji      = status.showRomaji
+    @showTranslation = status.showTranslation
     @hidePopup() unless @enabled
 
   _isInlineNode: (node) ->


### PR DESCRIPTION
I use Rikaikun on Chrome to just display the Hiragana, so I can practice my Kanji reading but I don't always want to see the translation. In Rikaikun this can be disabled.

I recently started using Safarikai, which is really clean and fast, but it was missing this feature. I added it in a simple way by adding two new options:
- Show Romaji (default on)
- Show Translation (default on)

When it formats to display, it checks these options and either adds the Romaji and Translation or not.

I also renamed the Translate option to Enabled, since that appears to be the actual purpose and it would conflict with being able to disable just the translation. Change the names of this stuff however you want.