### PR TITLE
Appex result limit and mouseover throttling

### DIFF
--- a/Safari Extension/Base.lproj/SafariExtensionViewController.xib
+++ b/Safari Extension/Base.lproj/SafariExtensionViewController.xib
@@ -10,6 +10,7 @@
             <connections>
                 <outlet property="highlightButton" destination="aS4-um-XK6" id="7Ju-hl-t94"/>
                 <outlet property="lookupButton" destination="DFC-4t-eHX" id="aED-1C-SkR"/>
+                <outlet property="resultLimitPopUp" destination="gG7-U6-dOj" id="N2L-IT-oyZ"/>
                 <outlet property="romajiButton" destination="hcQ-gA-ULX" id="nqb-Oh-th0"/>
                 <outlet property="translationButton" destination="J12-Tw-Ar7" id="yl0-F8-saa"/>
                 <outlet property="view" destination="c22-O7-iKe" id="vwT-Xx-Aiz"/>
@@ -18,11 +19,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="c22-O7-iKe">
-            <rect key="frame" x="0.0" y="0.0" width="175" height="130"/>
+            <rect key="frame" x="0.0" y="0.0" width="175" height="150"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DFC-4t-eHX">
-                    <rect key="frame" x="12" y="100" width="71" height="18"/>
+                    <rect key="frame" x="12" y="120" width="71" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Enabled" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="U6V-gQ-YDf">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -33,7 +34,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aS4-um-XK6">
-                    <rect key="frame" x="12" y="74" width="77" height="18"/>
+                    <rect key="frame" x="12" y="94" width="77" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Highlight" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="xUi-yA-9ua">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -44,7 +45,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hcQ-gA-ULX">
-                    <rect key="frame" x="12" y="46" width="100" height="18"/>
+                    <rect key="frame" x="12" y="66" width="100" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show Romaji" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="mf6-Go-sp9">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -55,7 +56,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="J12-Tw-Ar7">
-                    <rect key="frame" x="12" y="18" width="126" height="18"/>
+                    <rect key="frame" x="12" y="38" width="126" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Show Translation" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oPD-k0-x6c">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -65,8 +66,29 @@
                         <action selector="translationTogglePressed:" target="-2" id="XKI-59-8KE"/>
                     </connections>
                 </button>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Eya-Su-NDb">
+                    <rect key="frame" x="12" y="13" width="82" height="17"/>
+                    <autoresizingMask key="autoresizingMask"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" title="Results Limit" id="ikb-Es-zBP">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gG7-U6-dOj">
+                    <rect key="frame" x="98" y="8" width="76" height="26"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="n1O-zD-MZl">
+                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="menu"/>
+                        <menu key="menu" id="bat-TA-0FB"/>
+                    </popUpButtonCell>
+                    <connections>
+                        <action selector="resultLimitPressed:" target="-2" id="wFC-lx-Rgq"/>
+                    </connections>
+                </popUpButton>
             </subviews>
-            <point key="canvasLocation" x="60.5" y="156"/>
+            <point key="canvasLocation" x="58.5" y="167.5"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="MR8-4v-2Ir"/>
     </objects>

--- a/Safari Extension/SafariExtensionHandler.swift
+++ b/Safari Extension/SafariExtensionHandler.swift
@@ -35,7 +35,8 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
             
             let word = userInfo!["word"] as! String
             let url = userInfo!["url"] as! String
-            let (results, match) = SafarikaiEngine.JSDictionary.shared.search(word: word)
+            let limit = SettingsManager.shared.resultsLimit
+            let (results, match) = SafarikaiEngine.JSDictionary.shared.search(word, limit: limit)
             page.dispatchMessageToScript(withName: OutgoingMessage.showResult.rawValue, userInfo:
                 ["word": match ?? "", "url": url, "result": results]
             )

--- a/Safari Extension/SafariExtensionViewController.swift
+++ b/Safari Extension/SafariExtensionViewController.swift
@@ -16,22 +16,26 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
     @IBOutlet weak var highlightButton: NSButton!
     @IBOutlet weak var romajiButton: NSButton!
     @IBOutlet weak var translationButton: NSButton!
+    @IBOutlet weak var resultLimitPopUp: NSPopUpButton!
+    
+    private let resultOptions = Array(3...8)
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        preferredContentSize = NSSize(width: 175, height: 130)
+        preferredContentSize = NSSize(width: 175, height: 150)
         
         lookupButton.state = SettingsManager.shared.isLookupEnabled ? .on : .off
         highlightButton.state = SettingsManager.shared.isHighlightEnabled ? .on : .off
         romajiButton.state = SettingsManager.shared.isShowRomaji ? .on : .off
         translationButton.state = SettingsManager.shared.isShowTranslation ? .on : .off
+        resultLimitPopUp.addItems(withTitles: resultOptions.map {"\($0)"})
+        resultLimitPopUp.selectItem(withTitle: "\(SettingsManager.shared.resultsLimit)")
     }
     
     @IBAction func lookupTogglePressed(_ sender: NSButton) {
         SettingsManager.shared.isLookupEnabled = sender.state == .on
     }
-    
     
     @IBAction func highlightTogglePressed(_ sender: NSButton) {
         SettingsManager.shared.isHighlightEnabled = sender.state == .on
@@ -42,8 +46,12 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
         SettingsManager.shared.isShowRomaji = sender.state == .on
     }
     
-    
     @IBAction func translationTogglePressed(_ sender: NSButton) {
         SettingsManager.shared.isShowTranslation = sender.state == .on
+    }
+    
+    @IBAction func resultLimitPressed(_ sender: NSPopUpButton) {
+        let selectedLimit = resultOptions[sender.indexOfSelectedItem]
+        SettingsManager.shared.resultsLimit = selectedLimit
     }
 }

--- a/Safari Extension/dictionary.js
+++ b/Safari Extension/dictionary.js
@@ -122,7 +122,7 @@
       };
     };
 
-    Dictionary.prototype.load = function() {
+    Dictionary.prototype.load = function(loadedDict) {
       this.dict = loadedDict;
       // return readDataFile("data.js", (function(_this) {
       //   return function(data) {
@@ -155,8 +155,8 @@
     return flattened;
   };
 
-  readDataFile = function(file, success) {
-    return success("var loadedDict = {}");
-  };
+  // readDataFile = function(file, success) {
+  //   return success("var loadedDict = {}");
+  // };
 
 // }).call(this);

--- a/Safari Extension/injected.js
+++ b/Safari Extension/injected.js
@@ -3,6 +3,38 @@
   var Client, client,
     indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
+  function throttle(func, wait, options) {
+    var context, args, result;
+    var timeout = null;
+    var previous = 0;
+    if (!options) options = {};
+    var later = function() {
+      previous = options.leading === false ? 0 : Date.now();
+      timeout = null;
+      result = func.apply(context, args);
+      if (!timeout) context = args = null;
+    };
+    return function() {
+      var now = Date.now();
+      if (!previous && options.leading === false) previous = now;
+      var remaining = wait - (now - previous);
+      context = this;
+      args = arguments;
+      if (remaining <= 0 || remaining > wait) {
+        if (timeout) {
+          clearTimeout(timeout);
+          timeout = null;
+        }
+        previous = now;
+        result = func.apply(context, args);
+        if (!timeout) context = args = null;
+      } else if (!timeout && options.trailing !== false) {
+        timeout = setTimeout(later, remaining);
+      }
+      return result;
+    };
+  };
+
   Client = (function() {
     function Client(doc, window1) {
       this.doc = doc;
@@ -17,7 +49,7 @@
       this.showRomaji = true;
       this.showTranslation = true;
       this.rangeOffset = 0;
-      this.doc.onmousemove = (function(_this) {
+      this.doc.onmousemove = throttle((function(_this) {
         return function(e) {
           var ref;
           if (!(_this.enabled && !_this.mouseDown)) {
@@ -36,7 +68,7 @@
           }
           return true;
         };
-      })(this);
+      })(this), 25);
       this.doc.onmouseout = (function(_this) {
         return function(e) {
           return _this.hidePopup();

--- a/SafarikaiEngine/JSDictionary.swift
+++ b/SafarikaiEngine/JSDictionary.swift
@@ -34,8 +34,8 @@ public class JSDictionary {
         context.evaluateScript("this.dict.load( (function() {\(edictSource); return loadedDict;})() )")
     }
     
-    public func search(word: String) -> ([AnyObject], match: String?) {
-        guard let lookup = context.evaluateScript("this.dict.find('\(word)', 5)")!.toDictionary(),
+    public func search(_ word: String, limit: Int) -> ([AnyObject], match: String?) {
+        guard let lookup = context.evaluateScript("this.dict.find( '\(word)', \(limit) )")!.toDictionary(),
             let results = lookup["results"] as? [AnyObject],
             let match = lookup["match"] as? String else {
                 return ([], nil)

--- a/SafarikaiEngine/JSDictionary.swift
+++ b/SafarikaiEngine/JSDictionary.swift
@@ -22,17 +22,16 @@ public class JSDictionary {
         let deinflectSource = try! String.init(contentsOfFile: deinflectPath!)
         context.evaluateScript("this.Deinflect=\(deinflectSource)")
         
-        let edictPath = Bundle.main.path(forResource: "data", ofType: "js")
-        let edictSource = try! String.init(contentsOfFile: edictPath!)
-        context.evaluateScript(edictSource)
-        
         let dicPath = Bundle.main.path(forResource: "dictionary", ofType: "js")
         let dicSource = try! String.init(contentsOfFile: dicPath!)
         context.evaluateScript(dicSource)
         
         // prepareDictionary
         context.evaluateScript("this.dict = new Dictionary")
-        context.evaluateScript("this.dict.load()")
+        
+        let edictPath = Bundle.main.path(forResource: "data", ofType: "js")
+        let edictSource = try! String.init(contentsOfFile: edictPath!)
+        context.evaluateScript("this.dict.load( (function() {\(edictSource); return loadedDict;})() )")
     }
     
     public func search(word: String) -> ([AnyObject], match: String?) {

--- a/SafarikaiEngine/SettingsManager.swift
+++ b/SafarikaiEngine/SettingsManager.swift
@@ -17,6 +17,7 @@ class SettingsManager {
     static let shared = SettingsManager()
     private init() {
         isLookupEnabled = sharedUserDefaults.value(forKey: keys.lookupEnabled.rawValue) as? Bool ?? true
+        resultsLimit = sharedUserDefaults.value(forKey: keys.resultsLimit.rawValue) as? Int ?? 5
     }
     
     let sharedUserDefaults = UserDefaults(suiteName: "9A3W22M8YB.group.com.ashchan.Safarikai")!
@@ -49,8 +50,12 @@ class SettingsManager {
         get { return sharedUserDefaults.value(forKey: keys.translationShow.rawValue) as? Bool ?? true }
         set(value) { sharedUserDefaults.set(value, forKey: keys.translationShow.rawValue) }
     }
+    private var _resultsLimit: Int!
     var resultsLimit: Int {
-        get { return sharedUserDefaults.value(forKey: keys.resultsLimit.rawValue) as? Int ?? 5 }
-        set(value) { sharedUserDefaults.set(value, forKey: keys.resultsLimit.rawValue) }
+        get { return _resultsLimit }
+        set(value) {
+            sharedUserDefaults.set(value, forKey: keys.resultsLimit.rawValue)
+            _resultsLimit = value
+        }
     }
 }


### PR DESCRIPTION
Implement remaining features for feature-parity with older version.

## What's new?
* Added "result limit" setting option from 3 to 8 (default: 5)
* Use underscore.js's `throttle()` on `mouseover` event to 25ms to limit CPU usage (before: 13% avg, after: 5% avg when actively mousing over text).