### PR TITLE
Tweak load data performance

### DIFF
--- a/Safari Extension/SafariExtensionHandler.swift
+++ b/Safari Extension/SafariExtensionHandler.swift
@@ -20,6 +20,12 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
         case showResult
     }
 
+    override func beginRequest(with context: NSExtensionContext) {
+        super.beginRequest(with: context)
+
+        Dict.shared.load()
+    }
+
     override func messageReceived(withName messageName: String, from page: SFSafariPage, userInfo: [String: Any]?) {
         if !SettingsManager.shared.isLookupEnabled {
             return

--- a/Safarikai.xcodeproj/project.pbxproj
+++ b/Safarikai.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		1A5D35611DE9756600827D78 /* SafariExtensionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1A5D355F1DE9756600827D78 /* SafariExtensionViewController.xib */; };
 		1A5D35661DE9756600827D78 /* ToolbarItemIcon.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 1A5D35651DE9756600827D78 /* ToolbarItemIcon.pdf */; };
 		1A5D35691DE9756600827D78 /* Safari Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 1A5D35541DE9756600827D78 /* Safari Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		1A9AAE032168BA1500A6FE0A /* DictData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9AAE022168BA1500A6FE0A /* DictData.swift */; };
 		1AAD85AE1DF58771001A6B1A /* Deinflector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAD85AD1DF58771001A6B1A /* Deinflector.swift */; };
 		1AAD85C71DF5964A001A6B1A /* Romaji.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AAD85C61DF5964A001A6B1A /* Romaji.swift */; };
 		1AAD85C91DF59F29001A6B1A /* Regex.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AAD85C81DF59F29001A6B1A /* Regex.framework */; };
@@ -117,6 +118,7 @@
 		1A5D35601DE9756600827D78 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/SafariExtensionViewController.xib; sourceTree = "<group>"; };
 		1A5D35621DE9756600827D78 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1A5D35651DE9756600827D78 /* ToolbarItemIcon.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = ToolbarItemIcon.pdf; sourceTree = "<group>"; };
+		1A9AAE022168BA1500A6FE0A /* DictData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictData.swift; sourceTree = "<group>"; };
 		1AAD85AD1DF58771001A6B1A /* Deinflector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Deinflector.swift; sourceTree = "<group>"; };
 		1AAD85C61DF5964A001A6B1A /* Romaji.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Romaji.swift; sourceTree = "<group>"; };
 		1AAD85C81DF59F29001A6B1A /* Regex.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Regex.framework; path = Carthage/Build/Mac/Regex.framework; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 				1AAD85AD1DF58771001A6B1A /* Deinflector.swift */,
 				1AAD85C61DF5964A001A6B1A /* Romaji.swift */,
 				1A1206681DF6329100930307 /* Result.swift */,
+				1A9AAE022168BA1500A6FE0A /* DictData.swift */,
 				737C485B21563CCB00B16A35 /* Dictionary.swift */,
 				7393497A21568775009B2500 /* SettingsManager.swift */,
 				1AF01BE0216752510004E75E /* data.json */,
@@ -518,6 +521,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				737C485C21563CCB00B16A35 /* Dictionary.swift in Sources */,
+				1A9AAE032168BA1500A6FE0A /* DictData.swift in Sources */,
 				1A1206691DF6329100930307 /* Result.swift in Sources */,
 				7393497D21568775009B2500 /* SettingsManager.swift in Sources */,
 				1AAD85C71DF5964A001A6B1A /* Romaji.swift in Sources */,

--- a/Safarikai.xcodeproj/xcshareddata/xcschemes/SafarikaiEngineTests.xcscheme
+++ b/Safarikai.xcodeproj/xcshareddata/xcschemes/SafarikaiEngineTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1AF01BE521675B2B0004E75E"
+               BuildableName = "SafarikaiEngineTests.xctest"
+               BlueprintName = "SafarikaiEngineTests"
+               ReferencedContainer = "container:Safarikai.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SafarikaiEngine/DictData.swift
+++ b/SafarikaiEngine/DictData.swift
@@ -22,4 +22,13 @@ struct DictData: Decodable {
         words = (try? values.decode([String: [String]].self, forKey: .words)) ?? [:]
         indexes = (try? values.decode([String: [String]].self, forKey: .indexes)) ?? [:]
     }
+
+    init(json: [String: Any]) {
+        guard let words = json["words"] as? [String: [String]], let indexes = json["indexes"] as? [String: [String]] else {
+            fatalError("Parse json fail")
+        }
+
+        self.words = words
+        self.indexes = indexes
+    }
 }

--- a/SafarikaiEngine/DictData.swift
+++ b/SafarikaiEngine/DictData.swift
@@ -1,0 +1,25 @@
+//
+//  DictData.swift
+//  SafarikaiEngine
+//
+//  Created by James Chen on 2018/10/06.
+//  Copyright © 2018 ashchan.com. All rights reserved.
+//
+
+import Foundation
+
+struct DictData: Decodable {
+    var words: [String: [String]]
+    var indexes: [String: [String]]
+
+    enum CodingKeys: String, CodingKey {
+        case words
+        case indexes
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        words = (try? values.decode([String: [String]].self, forKey: .words)) ?? [:]
+        indexes = (try? values.decode([String: [String]].self, forKey: .indexes)) ?? [:]
+    }
+}

--- a/SafarikaiEngine/Dictionary.swift
+++ b/SafarikaiEngine/Dictionary.swift
@@ -32,7 +32,10 @@ public class Dict {
         let dictPath = Bundle(for: type(of: self)).path(forResource: "data", ofType: "json")!
         let loading = { [weak self] in
             if let data = try? Data(contentsOf: URL(fileURLWithPath: dictPath), options: .mappedIfSafe) {
-                self?.dictData = try? JSONDecoder().decode(DictData.self, from: data)
+                // self?.dictData = try? JSONDecoder().decode(DictData.self, from: data)
+                // JSONSerialization is 65% faster
+                let json = try! JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
+                self?.dictData = DictData(json: json)
             }
             self?.isLoading = true
         }

--- a/SafarikaiEngine/Dictionary.swift
+++ b/SafarikaiEngine/Dictionary.swift
@@ -47,11 +47,6 @@ public class Dict {
     }
 }
 
-struct DictData: Decodable {
-    var words: [String: [String]]
-    var indexes: [String: [String]]
-}
-
 extension Dict {
     /// Search a word.
     public func search(_ word: String, limit: Int = 5) -> ([Result], match: String?) {

--- a/SafarikaiEngineTests/SafarikaiEngineTests.swift
+++ b/SafarikaiEngineTests/SafarikaiEngineTests.swift
@@ -10,14 +10,21 @@ import XCTest
 @testable import SafarikaiEngine
 
 class SafarikaiEngineTests: XCTestCase {
-    func testLoadDict() {
+    func testLoadDictAsync() {
         measure {
-            _ = Dict.shared
+            Dict().load(async: true)
+        }
+    }
+
+    func testLoadDictSync() {
+        measure {
+            Dict().load(async: false)
         }
     }
 
     func testLookup() {
-        let dict = Dict.shared
+        let dict = Dict()
+        dict.load(async: false)
         var (results, match) = dict.search("台風")
         (results, match) = dict.search("呼びかけています")
         (results, match) = dict.search("あわせて読みたい")


### PR DESCRIPTION
For #36. For `data.json`, `JSONSerialization` is 200% faster than `JSONDecoder`.