### PR TITLE
Ignore IMG alt attributes for lookups

### DIFF
--- a/Safari Extension/injected.js
+++ b/Safari Extension/injected.js
@@ -61,10 +61,8 @@ class Client {
     this.clientY = e.clientY;
     const ele = this.doc.elementFromPoint(this.clientX, this.clientY);
     this.range = null;
-    if (["TEXTAREA", "INPUT"].includes(ele.tagName)) {
+    if (["TEXTAREA", "INPUT", "IMG"].includes(ele.tagName)) {
       return this.selectionText = "";
-    } else if (ele.tagName === "IMG") {
-      return this.selectionText = ele.alt.trim();
     } else if (this.getParents(ele, "[contenteditable]").length) {
       return this.selectionText = "";
     } else {


### PR DESCRIPTION
Problem: mousing over images causes Safarikai to lookup the alt text which isn't very helpful on image-heavy websites, plus you can't tokenize the text within properly. Thought it would be best to disable `<img alt>` lookup completely.

<img width="563" alt="Screen Shot 2020-07-04 at 1 02 00" src="https://user-images.githubusercontent.com/47551890/86486161-940edc00-bd95-11ea-9d6b-6dc462e75871.png">
