### PR TITLE
Add hold-to-lookup hotkey and img alt toggle

### DIFF
--- a/Safari Extension/SafariExtensionHandler.swift
+++ b/Safari Extension/SafariExtensionHandler.swift
@@ -35,7 +35,9 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
             "enabled": SettingsManager.shared.isLookupEnabled,
             "highlightText": SettingsManager.shared.isHighlightEnabled,
             "showRomaji": SettingsManager.shared.isShowRomaji,
-            "showTranslation": SettingsManager.shared.isShowTranslation
+            "showTranslation": SettingsManager.shared.isShowTranslation,
+            "lookupOnlyOnHotkey": SettingsManager.shared.shouldLookupOnlyOnHotkey,
+            "lookupImgAlt": SettingsManager.shared.shouldLookupImgAlt
         ]
 
         if messageName == IncomingMessage.lookupWord.rawValue {

--- a/Safari Extension/injected.js
+++ b/Safari Extension/injected.js
@@ -11,6 +11,8 @@ class Client {
     this.highlightText   = true;
     this.showRomaji      = true;
     this.showTranslation = true;
+    this.lookupOnlyOnHotkey = false;
+    this.lookupImgAlt = false;
     this.rangeOffset   = 0;
 
     this.doc.onmousemove = e => {
@@ -42,6 +44,18 @@ class Client {
       }
       return true;
     };
+      
+    this.doc.onkeydown = event => {
+        if (this.lookupOnlyOnHotkey && event.key === "Alt") {
+            this.mouseDown = false;
+        }
+    };
+    this.doc.onkeyup = event => {
+        if (this.lookupOnlyOnHotkey && event.key === "Alt") {
+            this.mouseDown = true;
+            this.clearHighlight();
+        }
+    };
 
     safari.self.addEventListener("message", e => {
       const messageData = e.message;
@@ -61,8 +75,10 @@ class Client {
     this.clientY = e.clientY;
     const ele = this.doc.elementFromPoint(this.clientX, this.clientY);
     this.range = null;
-    if (["TEXTAREA", "INPUT", "IMG"].includes(ele.tagName)) {
+    if (["TEXTAREA", "INPUT"].includes(ele.tagName)) {
       return this.selectionText = "";
+    } else if (this.lookupImgAlt && ele.tagName === "IMG") {
+       return this.selectionText = ele.alt.trim();
     } else if (this.getParents(ele, "[contenteditable]").length) {
       return this.selectionText = "";
     } else {
@@ -170,6 +186,8 @@ class Client {
     this.highlightText   = status.highlightText;
     this.showRomaji      = status.showRomaji;
     this.showTranslation = status.showTranslation;
+    this.lookupOnlyOnHotkey = status.lookupOnlyOnHotkey;
+    this.lookupImgAlt = status.lookupImgAlt;
     if (!this.enabled) { return this.hidePopup(); }
   }
 

--- a/Safarikai/Base.lproj/Main.storyboard
+++ b/Safarikai/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -600,7 +600,7 @@
                                         <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                             <connections>
-                                                <action selector="toggleSourceList:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
+                                                <action selector="toggleSidebar:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
@@ -686,11 +686,11 @@
             <objects>
                 <viewController id="XfG-lQ-9wD" customClass="ViewController" customModule="Safarikai" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" wantsLayer="YES" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="480" height="380"/>
+                        <rect key="frame" x="0.0" y="0.0" width="480" height="421"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="qLK-VL-DKN">
-                                <rect key="frame" x="18" y="218" width="444" height="102"/>
+                                <rect key="frame" x="18" y="265" width="444" height="96"/>
                                 <textFieldCell key="cell" id="nRy-H7-9Lq">
                                     <font key="font" metaFont="system"/>
                                     <string key="title">1. Open Safari and choose Safari &gt; Preferences.
@@ -703,7 +703,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kvu-tk-ln5">
-                                <rect key="frame" x="18" y="340" width="444" height="20"/>
+                                <rect key="frame" x="18" y="381" width="444" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="gLJ-Ie-1uy"/>
                                 </constraints>
@@ -714,7 +714,7 @@
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PyK-m3-tRq">
-                                <rect key="frame" x="14" y="169" width="452" height="33"/>
+                                <rect key="frame" x="14" y="216" width="452" height="33"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="KXP-Nc-AsD"/>
                                 </constraints>
@@ -727,7 +727,7 @@
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TyK-AW-gQZ">
-                                <rect key="frame" x="18" y="114" width="444" height="18"/>
+                                <rect key="frame" x="18" y="161" width="444" height="18"/>
                                 <buttonCell key="cell" type="check" title="Highlight" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Ipb-At-jvT">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -737,7 +737,7 @@
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VqQ-O9-Dwv">
-                                <rect key="frame" x="18" y="86" width="444" height="18"/>
+                                <rect key="frame" x="18" y="133" width="444" height="18"/>
                                 <buttonCell key="cell" type="check" title="Show Romaji" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ZeZ-r4-oni">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -747,7 +747,7 @@
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cbP-2x-Lkd">
-                                <rect key="frame" x="18" y="58" width="444" height="18"/>
+                                <rect key="frame" x="18" y="105" width="444" height="18"/>
                                 <buttonCell key="cell" type="check" title="Show Translation" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="6O2-v6-PLr">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -756,8 +756,18 @@
                                     <action selector="translationTogglePressed:" target="XfG-lQ-9wD" id="Z3B-CQ-Ow8"/>
                                 </connections>
                             </button>
+                            <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2xC-as-E0L">
+                                <rect key="frame" x="18" y="77" width="444" height="18"/>
+                                <buttonCell key="cell" type="check" title="Lookup Only While Pressing ⌥" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="wAL-s0-l1d">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="lookupOnlyOnHotkeyTogglePressed:" target="XfG-lQ-9wD" id="W7Y-kg-gKm"/>
+                                </connections>
+                            </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rJb-qq-LSv">
-                                <rect key="frame" x="18" y="24" width="82" height="17"/>
+                                <rect key="frame" x="18" y="17" width="82" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Results Limit" id="JcS-kL-6hd">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -765,13 +775,13 @@
                                 </textFieldCell>
                             </textField>
                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SHW-mH-srl">
-                                <rect key="frame" x="104" y="18" width="76" height="27"/>
+                                <rect key="frame" x="104" y="10" width="76" height="28"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="71" id="dUc-JE-l6I"/>
                                 </constraints>
                                 <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="W5d-3N-r7e">
                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="menu"/>
+                                    <font key="font" metaFont="system"/>
                                     <menu key="menu" id="A2U-SP-OfN"/>
                                 </popUpButtonCell>
                                 <connections>
@@ -779,7 +789,7 @@
                                 </connections>
                             </popUpButton>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qL8-gs-Q1D">
-                                <rect key="frame" x="18" y="148" width="444" height="20"/>
+                                <rect key="frame" x="18" y="195" width="444" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="5WN-5W-I8r"/>
                                 </constraints>
@@ -789,6 +799,16 @@
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
+                            <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DxA-cC-M3n">
+                                <rect key="frame" x="18" y="49" width="444" height="18"/>
+                                <buttonCell key="cell" type="check" title="Lookup Alt Text in Images" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="uVi-fw-Nco">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="lookupImgAltTogglePressed:" target="XfG-lQ-9wD" id="V5l-6R-S6O"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
                             <constraint firstItem="qLK-VL-DKN" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" id="4u4-Ab-L8H"/>
@@ -800,7 +820,9 @@
                             <constraint firstItem="TyK-AW-gQZ" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" id="F2d-mZ-Ytv"/>
                             <constraint firstItem="cbP-2x-Lkd" firstAttribute="leading" secondItem="rJb-qq-LSv" secondAttribute="leading" id="Gqc-ch-nfE"/>
                             <constraint firstItem="SHW-mH-srl" firstAttribute="baseline" secondItem="rJb-qq-LSv" secondAttribute="firstBaseline" id="Grh-le-y8T"/>
+                            <constraint firstItem="SHW-mH-srl" firstAttribute="top" secondItem="DxA-cC-M3n" secondAttribute="bottom" constant="14" id="Gt1-dj-s8Q"/>
                             <constraint firstItem="kvu-tk-ln5" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" id="OLM-jx-dVs"/>
+                            <constraint firstItem="2xC-as-E0L" firstAttribute="top" secondItem="cbP-2x-Lkd" secondAttribute="bottom" constant="14" id="OPf-Xe-pBH"/>
                             <constraint firstAttribute="trailing" secondItem="PyK-m3-tRq" secondAttribute="trailing" constant="20" id="Pjc-Ow-xlc"/>
                             <constraint firstAttribute="trailing" secondItem="kvu-tk-ln5" secondAttribute="trailing" constant="20" id="Q8y-x6-rSV"/>
                             <constraint firstAttribute="trailing" secondItem="SHW-mH-srl" secondAttribute="trailing" constant="303" id="STc-by-LP2"/>
@@ -812,8 +834,8 @@
                             <constraint firstAttribute="trailing" secondItem="TyK-AW-gQZ" secondAttribute="trailing" constant="20" id="ckQ-vc-2QU"/>
                             <constraint firstItem="cbP-2x-Lkd" firstAttribute="top" secondItem="VqQ-O9-Dwv" secondAttribute="bottom" constant="14" id="eXL-dc-9UB"/>
                             <constraint firstAttribute="trailing" secondItem="qLK-VL-DKN" secondAttribute="trailing" constant="20" id="eyM-TL-JXg"/>
-                            <constraint firstItem="SHW-mH-srl" firstAttribute="top" secondItem="cbP-2x-Lkd" secondAttribute="bottom" constant="16" id="j6X-0D-JBm"/>
                             <constraint firstItem="kvu-tk-ln5" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="20" id="ktL-wJ-iWX"/>
+                            <constraint firstItem="DxA-cC-M3n" firstAttribute="top" secondItem="2xC-as-E0L" secondAttribute="bottom" constant="14" id="my0-U4-njH"/>
                             <constraint firstItem="cbP-2x-Lkd" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" id="no8-wj-qcI"/>
                             <constraint firstItem="qL8-gs-Q1D" firstAttribute="top" secondItem="PyK-m3-tRq" secondAttribute="bottom" constant="8" id="qLk-ou-mdy"/>
                             <constraint firstItem="PyK-m3-tRq" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" id="rLA-aG-yxF"/>
@@ -824,6 +846,8 @@
                     </view>
                     <connections>
                         <outlet property="highlightButton" destination="TyK-AW-gQZ" id="Evb-TP-vzS"/>
+                        <outlet property="lookupImgAltButton" destination="DxA-cC-M3n" id="TaW-Ff-ao4"/>
+                        <outlet property="lookupOnlyOnHotkeyButton" destination="2xC-as-E0L" id="I7Y-IV-pJT"/>
                         <outlet property="resultLimitPopup" destination="SHW-mH-srl" id="xMk-Fg-aVl"/>
                         <outlet property="romajiButton" destination="VqQ-O9-Dwv" id="azJ-Ek-pAP"/>
                         <outlet property="translationButton" destination="cbP-2x-Lkd" id="Lfg-Yw-aqI"/>
@@ -831,7 +855,7 @@
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="75" y="732.5"/>
+            <point key="canvasLocation" x="75" y="752.5"/>
         </scene>
     </scenes>
 </document>

--- a/Safarikai/ViewController.swift
+++ b/Safarikai/ViewController.swift
@@ -13,6 +13,8 @@ class ViewController: NSViewController {
     @IBOutlet weak var highlightButton: NSButton!
     @IBOutlet weak var romajiButton: NSButton!
     @IBOutlet weak var translationButton: NSButton!
+    @IBOutlet weak var lookupOnlyOnHotkeyButton: NSButton!
+    @IBOutlet weak var lookupImgAltButton: NSButton!
     @IBOutlet weak var resultLimitPopup: NSPopUpButton!
 
     private let resultOptions = Array(3...8)
@@ -23,6 +25,8 @@ class ViewController: NSViewController {
         highlightButton.state = SettingsManager.shared.isHighlightEnabled ? .on : .off
         romajiButton.state = SettingsManager.shared.isShowRomaji ? .on : .off
         translationButton.state = SettingsManager.shared.isShowTranslation ? .on : .off
+        lookupOnlyOnHotkeyButton.state = SettingsManager.shared.shouldLookupOnlyOnHotkey ? .on : .off
+        lookupImgAltButton.state = SettingsManager.shared.shouldLookupImgAlt ? .on : .off
         resultLimitPopup.addItems(withTitles: resultOptions.map {"\($0)"})
         resultLimitPopup.selectItem(withTitle: "\(SettingsManager.shared.resultsLimit)")
     }
@@ -43,6 +47,14 @@ class ViewController: NSViewController {
 
     @IBAction func translationTogglePressed(_ sender: NSButton) {
         SettingsManager.shared.isShowTranslation = sender.state == .on
+    }
+
+    @IBAction func lookupOnlyOnHotkeyTogglePressed(_ sender: NSButton) {
+        SettingsManager.shared.shouldLookupOnlyOnHotkey = sender.state == .on
+    }
+
+    @IBAction func lookupImgAltTogglePressed(_ sender: NSButton) {
+        SettingsManager.shared.shouldLookupImgAlt = sender.state == .on
     }
 
     @IBAction func resultLimitPressed(_ sender: NSPopUpButton) {

--- a/SafarikaiEngine/SettingsManager.swift
+++ b/SafarikaiEngine/SettingsManager.swift
@@ -18,6 +18,8 @@ class SettingsManager {
         static let highlightEnabled = "highlightEnabled"
         static let romajiShow = "romajiShow"
         static let translationShow = "translationShow"
+        static let shouldLookupOnlyOnHotkey = "lookupOnlyOnHotkey"
+        static let shouldLookupImgAlt = "lookupImgAlt"
         static let resultsLimit = "resultsLimit"
     }
 
@@ -39,6 +41,16 @@ class SettingsManager {
     var isShowTranslation: Bool {
         get { return sharedUserDefaults.value(forKey: Keys.translationShow) as? Bool ?? true }
         set(value) { sharedUserDefaults.set(value, forKey: Keys.translationShow) }
+    }
+
+    var shouldLookupOnlyOnHotkey: Bool {
+        get { sharedUserDefaults.value(forKey: Keys.shouldLookupOnlyOnHotkey) as? Bool ?? true }
+        set(value) { sharedUserDefaults.set(value, forKey: Keys.shouldLookupOnlyOnHotkey) }
+    }
+
+    var shouldLookupImgAlt: Bool {
+        get { sharedUserDefaults.value(forKey: Keys.shouldLookupImgAlt) as? Bool ?? true }
+        set(value) { sharedUserDefaults.set(value, forKey: Keys.shouldLookupImgAlt) }
     }
 
     var resultsLimit: Int {

--- a/SafarikaiEngine/SettingsManager.swift
+++ b/SafarikaiEngine/SettingsManager.swift
@@ -44,7 +44,7 @@ class SettingsManager {
     }
 
     var shouldLookupOnlyOnHotkey: Bool {
-        get { sharedUserDefaults.value(forKey: Keys.shouldLookupOnlyOnHotkey) as? Bool ?? true }
+        get { sharedUserDefaults.bool(forKey: Keys.shouldLookupOnlyOnHotkey) }
         set(value) { sharedUserDefaults.set(value, forKey: Keys.shouldLookupOnlyOnHotkey) }
     }
 


### PR DESCRIPTION
Resolves #52 #49.

Added the following options by popular demand:
* Lookup only when holding ⌥ and mousing over
* Lookup `<img alt>` text

<img width="480" alt="Screen Shot 2020-08-11 at 12 11 43 AM" src="https://user-images.githubusercontent.com/3298414/89798562-48570b80-db67-11ea-9459-bf07dfb9123b.png">